### PR TITLE
Current NavPoint design

### DIFF
--- a/components/common/Nav.js
+++ b/components/common/Nav.js
@@ -17,7 +17,8 @@ export default function Nav({nopageHeader}) {
   const updatedNavigation = navigation.map((item) => ({
     ...item,
     current: item.href === router.pathname ||
-    (router.pathname.startsWith("/companies") && item.href === "/companies"),
+    (router.pathname.startsWith("/companies") && item.href === "/companies") ||
+    (router.pathname.startsWith("/persons") && item.href === "/persons")
   }));
   return (
     <Disclosure as="nav" className={`bg-primary-600 ${nopageHeader ? 'rounded-b-lg' : ''}`}>


### PR DESCRIPTION
Die `Nav` Kompontente hat nur bei Unterseiten von `/companies` den `Firmen` NavPoint als active gestylt.
Das funktioniert jetzt auch für Unterseiten von `/persons` für den `Personen` NavPoint