### PR TITLE
Everyone renders ServerSide #86

### DIFF
--- a/pages/companies.js
+++ b/pages/companies.js
@@ -32,7 +32,7 @@ const Companies = ({companies}) => {
 };
 export default Companies
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   try {
     const contentResponse = await fetcher(
       'companies', 

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,7 @@ const Index = ({companies, persons, texts, jumbotron}) => {
 
 export default Index
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   try {
     const companyResponse = await fetcher(
       'companies', 

--- a/pages/persons.js
+++ b/pages/persons.js
@@ -29,7 +29,7 @@ const Persons = ({persons}) => {
 }
 export default Persons
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   try {
     const contentResponse = await fetcher(
       `persons`,


### PR DESCRIPTION
Auch die Seiten `/index, /companies und /persons` sind beim Fetching auf `getServerSideProps()` umgestellt, damit die Listen die Daten aus Strapi immer aktuell darstellen