### PR TITLE
Network Fetching Bug

### DIFF
--- a/frontend/pages/hr/[id].js
+++ b/frontend/pages/hr/[id].js
@@ -61,7 +61,7 @@ export async function getServerSideProps({params}) {
     try {
         const contentResponse = await fetcher(
             `hr-publics/${id}`,
-            `populate[company][fields][0]=company_name,hr_dept,hr_number,pageslug&populate[docs][populate][mainDoc][fields][0]=url&populate[docs][populate][relatedDocs][populate][document][fields][0]=url`
+            'populate[company][fields][0]=company_name&populate[company][fields][1]=hr_dept&populate[company][fields][2]=hr_number&populate[company][fields][3]=pageslug&populate[docs][populate][mainDoc][fields][0]=url&populate[docs][populate][relatedDocs][populate][document][fields][0]=url'
         )
 
         const pub_text = await markdownToHtml(contentResponse.data.attributes.pub_text);

--- a/frontend/pages/persons/[id].js
+++ b/frontend/pages/persons/[id].js
@@ -73,7 +73,7 @@ export async function getServerSideProps({params}) {
     try{
         const contentResponse = await fetcher(
             `persons/${id}`,
-            'populate[networkChildren][populate][childCompany][fields][0]=company_name,hr_number,pageslug&populate[pubsMentioned][populate][company][fields][0]=company_name,pageslug'
+            'populate[networkChildren][populate][childCompany][fields][0]=hr_number&populate[networkChildren][populate][childCompany][fields][1]=company_name&populate[networkChildren][populate][childCompany][fields][2]=pageslug&populate[pubsMentioned][populate][company][fields][0]=hr_number&populate[pubsMentioned][populate][company][fields][1]=company_name&populate[pubsMentioned][populate][company][fields][2]=pageslug'
         )
         return {
             props: {


### PR DESCRIPTION
Strapi hatte ein Problem mit den Links, mit denen ich bisher das fetching umgesetzt hatte. Die `fields` müssen jetzt einzeln gefiltert werden.

Vorher:
`'populate[networkChildren][populate][childCompany][fields][0]=company_name,hr_number,pageslug&populate[pubsMentioned][populate][company][fields][0]=company_name,pageslug'`

Nachher:
`'populate[company][fields][0]=company_name&populate[company][fields][1]=hr_dept&populate[company][fields][2]=hr_number&populate[company][fields][3]=pageslug&populate[docs][populate][mainDoc][fields][0]=url&populate[docs][populate][relatedDocs][populate][document][fields][0]=url'`