### PR TITLE
NPM depupdate Script in Root

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,8 +8,7 @@
     "build": "strapi build",
     "build:win": "cross-env NODE_ENV=production npm run build",
     "strapi": "strapi",
-    "start:win": "cross-env NODE_ENV=production npm start",
-    "depupdate": "npm i && npm run build"
+    "start:win": "cross-env NODE_ENV=production npm start"
   },
   "dependencies": {
     "@strapi/plugin-i18n": "4.15.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:back": "cd backend && npm run build",
     "winbuild:back": "cd backend && npm run build:win",
     "start:frontend": "cd frontend && npm run start",
-    "backstart:win": "cd backend && npm run start:win"
+    "backstart:win": "cd backend && npm run start:win",
+    "depupdate": "concurrently -n ROOT,FRONT,BACK -c auto,auto,auto \"npm i\" \"cd frontend && npm i\" \"cd backend && npm i\""
   },
   "dependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
- Removed `depupdate` script from `backend/package.js`
- Added different `depupdate` script to `package.json` in root. This allows you to run `npm i` with concurrently in the root, `/frontend` and `/backend` after merging dependency updates.