### PR TITLE
Links auf ListItems

### DIFF
--- a/frontend/components/detailPages/Network.js
+++ b/frontend/components/detailPages/Network.js
@@ -38,68 +38,68 @@ export default function Network({networkInfo}) {
                 {activeParents.slice(0, numToShow).map((parent) => {
                     if (parent.attributes.parentCompany.data !== null) {
                         return (
-                            <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    <FontAwesomeIcon icon={faBuilding} size='lg' />
+                            <Link href={'/companies/'+parent.attributes.parentCompany.data.attributes.pageslug} >
+                                <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
+                                        <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                            <FontAwesomeIcon icon={faBuilding} size='lg' />
+                                        </div>
+                                        <div className={`${style.listContent} flex-auto`}>
+                                                <p className={`${style.summary}`}>{parent.attributes.parentCompany.data.attributes.company_name}</p>
+                                                <p className={`${style.meta}`}>{parent.attributes.type}</p>
+                                        </div>
                                 </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={'/companies/'+parent.attributes.parentCompany.data.attributes.pageslug} >
-                                        <p className={`${style.summary}`}>{parent.attributes.parentCompany.data.attributes.company_name}</p>
-                                        <p className={`${style.meta}`}>{parent.attributes.type}</p>
-                                    </Link>
-                                </div>
-                            </div>
+                            </Link>
                         )
 
                     } else if (parent.attributes.parentExternal.data !== null) {
                         return (
-                            <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    {parent.attributes.parentExternal.data.attributes.reg_dept == 'Behörde' ? (
-                                        <FontAwesomeIcon icon={faBuildingColumns} size='lg' />
-                                    ) : (
-                                        <FontAwesomeIcon icon={faIndustry} size='lg' />
-                                    )}
+                            <Link href={parent.attributes.parentExternal.data.attributes.url} target='_blank' >
+                                <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
+                                    <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                        {parent.attributes.parentExternal.data.attributes.reg_dept == 'Behörde' ? (
+                                            <FontAwesomeIcon icon={faBuildingColumns} size='lg' />
+                                        ) : (
+                                            <FontAwesomeIcon icon={faIndustry} size='lg' />
+                                        )}
+                                    </div>
+                                    <div className={`${style.listContent} flex-auto`}>
+                                            <p className={`${style.summary}`}>{parent.attributes.parentExternal.data.attributes.company_name}</p>
+                                            <p className={`${style.meta}`}>{parent.attributes.type}</p>
+                                    </div>
                                 </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={parent.attributes.parentExternal.data.attributes.url} target='_blank' >
-                                        <p className={`${style.summary}`}>{parent.attributes.parentExternal.data.attributes.company_name}</p>
-                                        <p className={`${style.meta}`}>{parent.attributes.type}</p>
-                                    </Link>
-                                </div>
-                            </div>
+                            </Link>
                         )
 
                     } else if (parent.attributes.parentPerson.data !== null) {
                         return (
-                            <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    <FontAwesomeIcon icon={faUser} size='lg' />
-                                </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={'/persons/'+parent.attributes.parentPerson.data.id} >
+                            <Link href={'/persons/'+parent.attributes.parentPerson.data.id} >
+                                <div className={`${style.networkItem} rounded-lg`} key={parent.id}>
+                                    <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                        <FontAwesomeIcon icon={faUser} size='lg' />
+                                    </div>
+                                    <div className={`${style.listContent} flex-auto`}>
                                         <p className={`${style.summary}`}>{parent.attributes.parentPerson.data.attributes.first_name} {parent.attributes.parentPerson.data.attributes.sir_name}</p>
                                         <p className={`${style.meta}`}>{parent.attributes.type}</p>
-                                    </Link>
+                                    </div>
                                 </div>
-                            </div>
+                            </Link>
                         )
                     }
                 })}
 
                 {ShowFullNetwork && activeChildren.map((child) => {
                     return (
-                        <div className={`${style.networkItem} rounded-lg`} key={child.id}>
-                            <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                <FontAwesomeIcon icon={faBuildingCircleArrowRight} size='lg'  />
-                            </div>
-                            <div className={`${style.listContent} flex-auto`}>
-                                <Link href={'/companies/'+child.attributes.childCompany.data.attributes.pageslug} >
+                        <Link href={'/companies/'+child.attributes.childCompany.data.attributes.pageslug} >
+                            <div className={`${style.networkItem} rounded-lg`} key={child.id}>
+                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                    <FontAwesomeIcon icon={faBuildingCircleArrowRight} size='lg'  />
+                                </div>
+                                <div className={`${style.listContent} flex-auto`}>
                                     <p className={`${style.summary}`}>{child.attributes.childCompany.data.attributes.company_name}</p>
                                     <p className={`${style.meta}`}>{child.attributes.type}</p>
-                                </Link>
+                                </div>
                             </div>
-                        </div>
+                        </Link>
                     )
                 })}
 
@@ -107,76 +107,76 @@ export default function Network({networkInfo}) {
                 {ShowFullNetwork && deletedParents.map((parent) => {
                     if (parent.attributes.parentCompany.data !== null) {
                         return (
-                            <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    <FontAwesomeIcon icon={faBuilding} size='lg' />
-                                </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={'/companies/'+parent.attributes.parentCompany.data.attributes.pageslug} >
+                            <Link href={'/companies/'+parent.attributes.parentCompany.data.attributes.pageslug} >
+                                <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
+                                    <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                        <FontAwesomeIcon icon={faBuilding} size='lg' />
+                                    </div>
+                                    <div className={`${style.listContent} flex-auto`}>
                                         <p className={`${style.summary}`}>{parent.attributes.parentCompany.data.attributes.company_name}</p>
                                         <p className={`${style.meta}`}>
                                             {parent.attributes.type} ({germanDate(parent.attributes.since)} bis {germanDate(parent.attributes.upto)})
                                         </p>
-                                    </Link>
+                                    </div>
                                 </div>
-                            </div>
+                            </Link>
                         )
 
                     } else if (parent.attributes.parentExternal.data !== null) {
                         return (
-                            <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    {parent.attributes.parentExternal.data.attributes.reg_dept == 'Behörde' ? (
-                                        <FontAwesomeIcon icon={faBuildingColumns} size='lg' />
-                                    ) : (
-                                        <FontAwesomeIcon icon={faIndustry} size='lg' />
-                                    )}
-                                </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={parent.attributes.parentExternal.data.attributes.url} target='_blank' >
+                            <Link href={parent.attributes.parentExternal.data.attributes.url} target='_blank' >
+                                <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
+                                    <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                        {parent.attributes.parentExternal.data.attributes.reg_dept == 'Behörde' ? (
+                                            <FontAwesomeIcon icon={faBuildingColumns} size='lg' />
+                                        ) : (
+                                            <FontAwesomeIcon icon={faIndustry} size='lg' />
+                                        )}
+                                    </div>
+                                    <div className={`${style.listContent} flex-auto`}>
                                         <p className={`${style.summary}`}>{parent.attributes.parentExternal.data.attributes.company_name}</p>
                                         <p className={`${style.meta}`}>
                                             {parent.attributes.type} ({germanDate(parent.attributes.since)} bis {germanDate(parent.attributes.upto)})
                                         </p>
-                                    </Link>
+                                    </div>
                                 </div>
-                            </div>
+                            </Link>
                         )
 
                     } else if (parent.attributes.parentPerson.data !== null) {
                         return (
-                            <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
-                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                    <FontAwesomeIcon icon={faUser} size='lg' />
-                                </div>
-                                <div className={`${style.listContent} flex-auto`}>
-                                    <Link href={'/persons/'+parent.attributes.parentPerson.data.id} >
+                            <Link href={'/persons/'+parent.attributes.parentPerson.data.id} >
+                                <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={parent.id}>
+                                    <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                        <FontAwesomeIcon icon={faUser} size='lg' />
+                                    </div>
+                                    <div className={`${style.listContent} flex-auto`}>
                                         <p className={`${style.summary}`}>{parent.attributes.parentPerson.data.attributes.first_name} {parent.attributes.parentPerson.data.attributes.sir_name}</p>
                                         <p className={`${style.meta}`}>
                                             {parent.attributes.type} ({germanDate(parent.attributes.since)} bis {germanDate(parent.attributes.upto)})
                                         </p>
-                                    </Link>
+                                    </div>
                                 </div>
-                            </div>
+                            </Link>
                         )
                     }
                 })}
 
                 {ShowFullNetwork && deletedChildren.map((child) => {
                     return (
-                        <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={child.id}>
-                            <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                <FontAwesomeIcon icon={faBuildingCircleArrowRight} size='lg' />
-                            </div>
-                            <div className={`${style.listContent} flex-auto`}>
-                                <Link href={'/companies/'+child.attributes.childCompany.data.attributes.pageslug} >
+                        <Link href={'/companies/'+child.attributes.childCompany.data.attributes.pageslug} >
+                            <div className={`${style.networkItem} ${style.deleted} rounded-lg`} key={child.id}>
+                                <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                    <FontAwesomeIcon icon={faBuildingCircleArrowRight} size='lg' />
+                                </div>
+                                <div className={`${style.listContent} flex-auto`}>
                                     <p className={`${style.summary}`}>{child.attributes.childCompany.data.attributes.company_name}</p>
                                     <p className={`${style.meta}`}>
                                         {child.attributes.type} ({germanDate(child.attributes.since)+' bis '+germanDate(child.attributes.upto)})
                                     </p>
-                                </Link>
+                                </div>
                             </div>
-                        </div>
+                        </Link>
                     )
                 })}
 

--- a/frontend/pages/lei/[leiPageslug].js
+++ b/frontend/pages/lei/[leiPageslug].js
@@ -146,16 +146,16 @@ const LEIDetail = ({item, network}) => {
                     <h4 className="mb-3 sectionLabel">Netzwerk</h4>
                     {network.map((relation) => (
                         relation.attributes.childCompany.data.attributes.pageslug != item.attributes.company.data.attributes.pageslug ? (
+                        <Link href={
+                            relation.attributes.childCompany.data.attributes.lei.data !== null ? (
+                                '/lei/'+ relation.attributes.childCompany.data.attributes.lei.data.attributes.identifier) : (
+                                '/companies/'+relation.attributes.childCompany.data.attributes.pageslug
+                        )} >
                         <div className={`${style.networkItem} my-4 rounded-lg`} key={relation.id}>
-                        <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                                <FontAwesomeIcon icon={faBuilding} size="lg" />
-                        </div>
-                        <div className={`${style.listContent} flex-auto`}>
-                            <Link href={
-                                relation.attributes.childCompany.data.attributes.lei.data !== null ? (
-                                    '/lei/'+ relation.attributes.childCompany.data.attributes.lei.data.attributes.identifier) : (
-                                    '/companies/'+relation.attributes.childCompany.data.attributes.pageslug
-                            )} >
+                            <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                    <FontAwesomeIcon icon={faBuilding} size="lg" />
+                            </div>
+                            <div className={`${style.listContent} flex-auto`}>
                                 <p className={`${style.summary} items-center inline-flex`}>
                                     <span >{relation.attributes.childCompany.data.attributes.company_name}</span>
                                     <span className={`badge ${style.StatusBadge}`}>Tochtergesellschaft</span>    
@@ -163,23 +163,23 @@ const LEIDetail = ({item, network}) => {
                                 {relation.attributes.childCompany.data.attributes.lei.data !== null ? (
                                     <p className={`${style.meta}`}>{relation.attributes.childCompany.data.attributes.lei.data.attributes.identifier}</p>
                                 ) : ''}
-                            </Link>
-                        </div>
-                    </div>
-                    ) :
-                    relation.attributes.parentCompany.data.attributes.pageslug != item.attributes.company.data.attributes.pageslug ? (
-                        <div className={`${style.networkItem} my-4 rounded-lg`} key={relation.id}>
-                        <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
-                            <div className={style.faIcon}>
-                                <FontAwesomeIcon icon={faBuilding} />
                             </div>
                         </div>
-                        <div className={`${style.listContent} flex-auto`}>
-                            <Link href={
-                                relation.attributes.parentCompany.data.attributes.lei.data !== null ? (
-                                    '/lei/'+ relation.attributes.parentCompany.data.attributes.lei.data.attributes.identifier) : (
-                                    '/companies/'+relation.attributes.parentCompany.data.attributes.pageslug
-                            )}>
+                    </Link>
+                    ) :
+                    relation.attributes.parentCompany.data.attributes.pageslug != item.attributes.company.data.attributes.pageslug ? (
+                        <Link href={
+                            relation.attributes.parentCompany.data.attributes.lei.data !== null ? (
+                                '/lei/'+ relation.attributes.parentCompany.data.attributes.lei.data.attributes.identifier) : (
+                                '/companies/'+relation.attributes.parentCompany.data.attributes.pageslug
+                        )}>
+                        <div className={`${style.networkItem} my-4 rounded-lg`} key={relation.id}>
+                            <div className={` ${style.listIcon} flex-none rounded-l-lg`}>
+                                <div className={style.faIcon}>
+                                    <FontAwesomeIcon icon={faBuilding} />
+                                </div>
+                            </div>
+                            <div className={`${style.listContent} flex-auto`}>
                                 <p className={`${style.summary} items-center inline-flex`}>
                                     <span>{relation.attributes.parentCompany.data.attributes.company_name}</span>
                                     <span className={`badge ${style.StatusBadge}`}>Muttergesellschaft</span>    
@@ -187,9 +187,9 @@ const LEIDetail = ({item, network}) => {
                                 {relation.attributes.parentCompany.data.attributes.lei.data !== null ? (
                                     <p className={`${style.meta}`}>{relation.attributes.parentCompany.data.attributes.lei.data.attributes.identifier}</p>
                                 ) : ''}
-                            </Link>
+                            </div>
                         </div>
-                    </div>
+                    </Link>
                     ) : ''
                     ))}
                 </section>

--- a/frontend/pages/persons/[id].js
+++ b/frontend/pages/persons/[id].js
@@ -35,19 +35,19 @@ const PersonDetail = ({item}) => {
                                 .sort((newest, oldest) => oldest.attributes.since.localeCompare(newest.attributes.since))
                                 .map((person) => {
                                 return (
-                                    <div className={`${style.listItem} ${person.attributes.upto ? (style.deleted) : ''} rounded-lg`}>
-                                        <div className={`${style.listIcon} flex-none rounded-l-lg`}>
-                                            <FontAwesomeIcon icon={faBuilding} size="lg" />
-                                        </div>
-                                        <div className={`${style.listContent} flex-auto`}>
-                                            <Link href={'/companies/'+person.attributes.childCompany.data.attributes.pageslug} key={person.id}>
+                                    <Link href={'/companies/'+person.attributes.childCompany.data.attributes.pageslug} key={person.id}>
+                                        <div className={`${style.listItem} ${person.attributes.upto ? (style.deleted) : ''} rounded-lg`}>
+                                            <div className={`${style.listIcon} flex-none rounded-l-lg`}>
+                                                <FontAwesomeIcon icon={faBuilding} size="lg" />
+                                            </div>
+                                            <div className={`${style.listContent} flex-auto`}>
                                                 <p className={`${style.summary}`}>{person.attributes.childCompany.data.attributes.company_name}</p>
                                                 <p className={`${style.meta}`}>
                                                     {person.attributes.type} {person.attributes.upto ? ('(bis '+germanDate(person.attributes.upto)+')') : ''}
                                                 </p>
-                                            </Link>
+                                            </div>
                                         </div>
-                                    </div>
+                                    </Link>
                                 );
                             })}
                         </div>


### PR DESCRIPTION
Die Links, auf die ListItems verweisen sollen, sollten jetzt überall wo es möglich ist auf dem kompletten Item und nicht nur auf dem `p` oder `Icon` liegen.

In der `HRList` ist das nicht möglich, da bei den Einträgen mit einem über Attribut dann ein `Link` im `Link` liegen würde.