### PR TITLE
CompanyDetail/NetworkInfo/parentExternal.url null workaround

### DIFF
--- a/frontend/components/detailPages/Network.js
+++ b/frontend/components/detailPages/Network.js
@@ -209,7 +209,9 @@ export default function Network({ networkInfo }) {
             } else if (parent.attributes.parentExternal.data !== null) {
               return (
                 <Link
-                  href={parent.attributes.parentExternal.data.attributes.url}
+                  href={
+                    parent.attributes.parentExternal.data.attributes.url || "#"
+                  }
                   target="_blank"
                 >
                   <div


### PR DESCRIPTION
Überall im Company Network wo auf die `parentExternal.url` verlinkt wird habe ich nun folgendes Snippet verändert:

```
<Link
    href={parent.attributes.parentExternal.data.attributes.url || "#" }
    target="_blank"
 >
...
</Link>
```

So wird nun bei externen Mutterunternehmen, bei denen in Strapi keine URL hinterlegt ist, einfach auf `#` verlinkt.