### PR TITLE
Temporary Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/payload" # Location of package manifests
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "14:00"
+      interval: "daily"
     reviewers:
       - "onissen"
     labels:


### PR DESCRIPTION
Vorübergehend soll Dependabot nur den /payload Unterordner betrachten und sofort einen PR anlegen. Diese Änderung wird später wieder zurückgefahren.