### PR TITLE
fix: Remove compiler option baseUrl from tsconfig

### DIFF
--- a/payload/tsconfig.json
+++ b/payload/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
     "incremental": true,
     "isolatedModules": true,


### PR DESCRIPTION
baseUrl is deprecated in Typescript 6 and can be removed. See https://github.com/microsoft/TypeScript/issues/62508