### PR TITLE
fix: use shorthand id fetching in payload.findbyId request

### DIFF
--- a/payload/src/app/(frontend)/designs/[id]/page.tsx
+++ b/payload/src/app/(frontend)/designs/[id]/page.tsx
@@ -18,8 +18,7 @@ export async function generateMetadata({
   const { id } = await params;
   const designMetadata = await payload.findByID({
     collection: "designs",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internals
-    id: id,
+    id,
     select: { type: true, wordmarkTitle: true },
   });
 
@@ -34,8 +33,7 @@ export default async function Page({
   const { id } = await params;
   const design = await payload.findByID({
     collection: "designs",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internals
-    id: id,
+    id,
     select: {
       type: true,
       wordmarkTitle: true,

--- a/payload/src/app/(frontend)/hr_publications/[id]/page.tsx
+++ b/payload/src/app/(frontend)/hr_publications/[id]/page.tsx
@@ -21,8 +21,7 @@ export async function generateMetadata({
   const { id } = await params;
   const pubMetadata = await payload.findByID({
     collection: "hr_publications",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: payload internal
-    id: id,
+    id,
     select: {
       title: true,
     },
@@ -38,8 +37,7 @@ export default async function Page({
   const { id } = await params;
   const item = await payload.findByID({
     collection: "hr_publications",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: payload internals
-    id: id,
+    id,
     select: {
       title: true,
       summary: true,

--- a/payload/src/app/(frontend)/lei/[id]/page.tsx
+++ b/payload/src/app/(frontend)/lei/[id]/page.tsx
@@ -19,8 +19,7 @@ export async function generateMetadata({
   const { id } = await params;
   const leiMetadata = await payload.findByID({
     collection: "lei",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internal
-    id: id,
+    id,
     select: { id: true },
   });
 
@@ -35,8 +34,7 @@ export default async function Page({
   const { id } = await params;
   const lei = await payload.findByID({
     collection: "lei",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internal
-    id: id,
+    id,
     select: {
       company: true,
       firstRegistration: true,

--- a/payload/src/app/(frontend)/persons/[id]/page.tsx
+++ b/payload/src/app/(frontend)/persons/[id]/page.tsx
@@ -22,8 +22,7 @@ export async function generateMetadata({
   const { id } = await params;
   const personMetadata = await payload.findByID({
     collection: "persons",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internal
-    id: id,
+    id,
     select: { firstName: true, sirName: true, city: true },
   });
   return {
@@ -40,8 +39,7 @@ export default async function Page({
 
   const person = await payload.findByID({
     collection: "persons",
-    // biome-ignore lint/style/useConsistentObjectDefinitions: Payload SDK internals
-    id: id,
+    id,
     select: {
       firstName: true,
       sirName: true,


### PR DESCRIPTION
Dort, wo `findById` auf den Paramter `id` zugreift, muss bei `findById` Aufrufen nicht `id: id` verwendet werden. Damit wird auch die Biome-Regel `lint/style/useConsistentObjectDefinitions` berücksichtigt