### PR TITLE
fix: The changesets config is migrated to work with @changesets/cli v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "access": "restricted",
+  "baseBranch": "main",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
+  "format": false,
+  "ignore": [],
   "linked": [],
-  "access": "restricted",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+  "privatePackages": {
+    "tag": true,
+    "version": true
+  },
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
changesets had to be actively enabled for the private package, changesets will not run any formatting.